### PR TITLE
v0.1.0 prepared for release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v0.1.0 - 2022-10-27
+
+### Changed
+* Starting semantic versioning of the model code at v0.1.0.
+* Made the `parm.util.pre_equilibration` function private by renaming to `parm.util._pre_equilibration`.
+* The main PARM model `parm.parm` is now imported in the package `__init__.py` so that it can be imported like `from parm import model`.
+* Moved the pysb dependency in setup.py to the `install_requires` list.
+
+### Added
+* Additional sections (Install, License, etc.) and information in the README, as well as shields/badges towards the top of the README.
+* New wrapper function for pre-equilibration in the `util` module, `parm.util.pre_equilibrate` that calls the `_pre_equilibration` function but also does addtional steps to automate the process of setting 2AT to zero concentration and adjusting the baseline cytosolic calcium concentration used for the FRET ratio. This function also has a simpler output that contains an updated parameter vector and the initial concentrations that can be directly passed to the `run_model` function.
+* New utility function `parm.util.calcium_homeostasis_reverse_rate_coupling` that adjusts a parameter vector to account for coupling of the reverse rates of the calcium homeostasis reactions to the forward rates. This function can be used adjust the parameters when sampling values of the reverse rate parameters for those reactions: for example, during model training.
+* New default parameter vector, `default_param_values` created in the package `__init__.py` for the main `parm.parm` model which can be imported like `from parm import default_param_values`.
+* New dictionary of parameter vector masks for fancy indexing, `parameter_masks`, created for the main `parm.parm` model which can imported like `from parm import parameter_masks`.
+* Utility function `parm.util.get_parameter_vector` that takes a PySB model and returns a vector of the parameter values.
+* Utiltiy function `parm.util.get_parameter_mask` that takes a PySB model and parameter name and returns a boolean mask to fancy index the corresponding paramter value vector for that particular parameter.
+* Utility function `parm.util.set_tat_initial_nM` that takes a parameter value vector and an initial concentration of 2AT in nM and updates the parameter vector with the desired 2AT concentration.
+
+### Fixed
+* Converted the `extras_require` argument in the setup.py to be dictionary instead of a list, now with just the optional Cython dependency. Note that the pysb dependency was moved into the `install_requires` list.
+* Commented out the `long_description` in setup.py because it was causing error when trying to read the README file.  
+
+
 ## [branch: setup-script-and-run-function] - 2022-10-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,10 +1,103 @@
 # PARM
-**P**AR2 **A**ctivation and calcium signaling **R**eaction **M**odel
+
+
+![Python version badge](https://img.shields.io/badge/python-3.8-blue.svg)
+[![PySB version badge](https://img.shields.io/badge/PySB->%3D1.13.2-9cf.svg)](https://pysb.org/)
+[![license](https://img.shields.io/github/license/NTBEL/PARM.svg)](LICENSE)
+![version](https://img.shields.io/badge/version-0.1.0-orange.svg)
+[![release](https://img.shields.io/github/release-pre/NTBEL/PARM.svg)](https://github.com/NTBEL/PARM/releases/tag/v0.1.0)
+
+**P**AR2 **A**ctivation and calcium signaling **R**eaction **M**odel (PARM)
 
 PARM contains rules-based models of PAR2 (proteinase-activated receptor isoform 2) activation, G-protein activation, and calcium signaling via the phospholipase C and IP3 (inositol triphosphate) pathway. Models are encoded as Python program modules using the [PySB](http://pysb.org/) modeling framework. The models are designed to mathematically model the underlying signaling dynamics relevant to the inactivation of PAR2 in HEK-293 cells by Molecular Hyperthermia as described in:
 
   Kang et al.,  Transient Photoinactivation of Cell Membrane Protein Activity without Genetic Modification by Molecular Hyperthermia, ACS Nano 2019, 13, 11, 12487–12499 [https://doi.org/10.1021/acsnano.9b01993](https://doi.org/10.1021/acsnano.9b01993)
 
+## Table of Contents
+
+  1. [Install](#install)
+    1. [Dependencies](#dependencies)
+    2. [pip install](#pip-install)
+    3. [Manual install](#manual-install)
+    4. [Recommended additional software](#recommended-additional-software)
+  2. [License](#license)
+  3. [Change Log](#change-log)
+  4. [Documentation and Usage](#documentation-and-usage)
+    1. [Models in PARM](#models-in-parm)
+    2. [Quick Overview](#quick-overview)
+  5. [Contact](#contact)
+  6. [Citing](#citing)  
+
+  ------
+
+# Install
+
+**PARM** installs as the `parm` Python package. It is tested with Python 3.8.
+
+### Dependencies
+Note that `parm` has the following core dependency:
+   * [PySB](https://pysb.org/) >= 1.13.2
+
+### pip install
+First, install [PySB](https://pysb.org/download).
+
+You can then install `parm` version 0.1.0 with `pip` sourced from the GitHub repo:
+
+##### with git installed:
+Fresh install:
+```
+pip install git+https://github.com/NTBEL/PARM@v0.1.0
+```
+Or to upgrade from an older version:
+```
+pip install --upgrade git+https://github.com/NTBEL/PARM@v0.1.0
+```
+##### without git installed:
+Fresh install:
+```
+pip install https://github.com/NTBEL/diffusion-fit/archive/refs/tags/v0.1.0.zip
+```
+Or to upgrade from an older version:
+```
+pip install --upgrade https://github.com/NTBEL/diffusion-fit/archive/refs/tags/v0.1.0.zip
+```
+### Manual install
+First, install [PySB](https://pysb.org/download).
+Then, download the repository and from the `PARM` folder/directory run
+```
+pip install .
+```
+
+### Recommended additional software
+
+The following software is not required for the basic operation of **parm**, but provide extra capabilities and features when installed.
+
+#### Cython
+[Cython](https://cython.org/) is used by PySB to compile the ODE reactions on-the-fly, which can greatly improve model performance when running with the `ScipyOdeSimulator`.
+
+pip:
+```
+pip install Cython
+```
+conda:
+```
+conda install cython
+```
+------    
+
+# License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) file for details
+
+------
+
+# Change Log
+
+See: [CHANGELOG](CHANGELOG.md)
+
+------
+
+# Documentation and Usage
 
 ## Models in PARM
 The core model of PARM is defined in `parm.parm`.
@@ -18,4 +111,71 @@ The core model of PARM is defined in `parm.parm`.
 There are also 3 models with mechanistic variations defined in `parm.variants`:
   * `parm.variants.precoupled` - Adds pre-coupling between PAR2 and the G-protein heterotrimer such that some PAR2 can bind to the heterotrimer under resting conditions (without any agonist).
   * `parm.variants.heterogprot_cycle` - The receptor binding and G-protein interaction mechanism is adapted from the yeast G-protein cycle model of [Yi et al. 2003](https://doi.org/10.1073/pnas.1834247100).
-  * `parm.variants.par2_synthesis_degradation` - This model only contains PAR2 with reactions for its resting synthesis and degradation. 
+  * `parm.variants.par2_synthesis_degradation` - This model only contains PAR2 with reactions for its resting synthesis and degradation.
+
+### Example usage
+
+```
+from parm.parm import model
+from parm.util import run_model
+
+tspan = list(range(0, 10, 1))
+
+traj_out = run_model(model, tspan)
+```
+
+### Note on pre-equlibration
+The main parm model includes some calcium homeostasis reactions that may require pre-eqilibration before running the actual simulation. This affects the calcium concentrations in different compartments and can affect the estimate of the FRET ratio. The model can pre-equilibrated using the `parm.util.pre_equilibration` function. Here is an example:
+
+```
+from parm.parm import model
+from parm.util import pre_equilibrate
+import numpy as np
+from pysb.simulator import ScipyOdeSimulator
+
+# set the time span for pre-eqilibration.
+tspan_pre = list(range(0, 3000, 1))
+# Get a vector of the parameter values.
+param_values = np.array([param.value for param in model.parameters])
+# Make a mask for the initial concentration of the agonist, 2AT, and set
+# it to zero.
+two_at_mask = np.array([param.name='TAT_0' for param in model.parameters])
+two_at_initial = param_values[two_at_mask]
+param_values[two_at_mask] = 0
+# Run the pre-equlibration.
+t_eq, conc_eq, cytoCa_eq, erCa_eq = pre_equilibration(model,
+                                                      tspan_pre,
+                                                      parameters=param_values,
+                                                      tolerance=100)
+
+# Mask for the resting cytosolic Ca2+ amount for the FRET estimation.
+cacrest_mask = [param.name=='Ca_C_resting' for param in model.parameters]
+# Adjust the FRET parameter affected by the initial cytosol calcium concentration.
+param_values[cacrest_mask] = cytoCa_eq[0]
+
+# Reset the intial 2AT concentration.
+param_values[two_at_mask] = two_at_initial
+
+# set the time span for the simulation.
+tspan = list(range(0, 300, 1))                                                      
+# Setup the PySB solver/simulator.
+solver = ScipyOdeSimulator(model, tspan=tspan, integrator='lsoda')
+# Run the simulation.
+sim = solver.run(param_values=param_values, initials=conc_eq[0])
+
+```
+
+------
+
+# Contact
+
+Please open a [GitHub Issue](https://github.com/NTBEL/PARM/issues) to
+report any problems/bugs or make any comments, suggestions, or feature requests for PARM.
+
+If you need assistance with PySB-specific issues then you can also try the pysb gitter channel: https://gitter.im/pysb/pysb
+
+------
+
+# Citing
+If this model or other package features are useful in your research and you wish to cite it, you can use the following software citation:
+> B. A. Wilson, “PARM: PAR2 Activation and calcium signaling Reaction Model in PySB” (v0.1.0), https://github.com/NTBEL/PARM, 2022.

--- a/parm/__init__.py
+++ b/parm/__init__.py
@@ -4,7 +4,7 @@ import numpy as np
 from .parm import model
 
 # Make a vector of the default model parameters.
-default_param_values = [param.value for param in model.parameters]
+default_param_values = np.array([param.value for param in model.parameters])
 
 # Create a dictionary of pamameter masks for fancy boolean indexing of the
 # the parameter vector.

--- a/parm/__init__.py
+++ b/parm/__init__.py
@@ -1,9 +1,13 @@
-# Import and alias models
-# from .classic_1 import model as classic_1
-# from .classic_2m import model as classic_2m
-# from .classic_2f import model as classic_2f
-# from .precoupled_1 import model as precoupled_1
-# from .precoupled_2m import model as precoupled_2m
-# from .precoupled_2f import model as precoupled_2f
-# # Import conversion factors
-# from .classic_1 import nM_to_num_per_pL, microM_to_num_per_pL, nM_2AT_to_num
+import numpy as np
+
+# Import the main model.
+from .parm import model
+
+# Make a vector of the default model parameters.
+default_param_values = [param.value for param in model.parameters]
+
+# Create a dictionary of pamameter masks for fancy boolean indexing of the
+# the parameter vector.
+parameter_masks = dict()
+for param in model.parameters:
+    parameter_masks[param.name] = [par.name == param.name for par in model.parameters]

--- a/parm/util.py
+++ b/parm/util.py
@@ -210,7 +210,12 @@ def get_parameter_mask(
     return [par.name == param_name for par in model.parameters]
 
 
-def set_tat_initial_nM(param_values, tat_conc_nM):
+def set_tat_initial_nM(
+    param_values: np.array,
+    tat_conc_nM: float,
+) -> np.array:
+    """Returns an updated parameter vector with the desired 2AT initial concentration."""
+
     # Mask for initial concentration of 2AT
     twoat_mask = parameter_masks["TAT_0"]
     vextra_mask = parameter_masks["Vextra"]

--- a/scripts/run_parm.py
+++ b/scripts/run_parm.py
@@ -1,23 +1,19 @@
 import numpy as np
-from pysb.simulator import ScipyOdeSimulator
 import matplotlib.pyplot as plt
-from parm.parm import model
-from parm import units
+
+from parm import model, default_param_values
+from parm import util
 
 tspan = np.linspace(0, 300, num=600, endpoint=True)
-solver = ScipyOdeSimulator(model, tspan=tspan, integrator="lsoda")
-param_values = np.array([parm.value for parm in model.parameters])
-# Mask for initial concentration of 2AT
-twoat_mask = [parm.name == "TAT_0" for parm in model.parameters]
-param_values[twoat_mask] = (
-    316 * units.nM_to_molec_per_pL * model.parameters["Vextra"].value
-)
+
+# Input the inital 2AT concentration as 316.0 nM.
+param_values = util.set_tat_initial_nM(default_param_values, 316.0)
+
 print("running PARM...")
-m_run = solver.run(param_values=param_values)
-yout = m_run.all
+traj_out = util.run_model(model, tspan, param_values=param_values)
 print("Done running...")
 
-plt.plot(tspan, yout["FRET"], label="FRET")
+plt.plot(tspan, traj_out["FRET"], label="FRET")
 plt.ylabel("FRET Ratio")
 plt.xlabel("Time (s)")
 plt.show()

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,19 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+# with open("README.md", encoding="utf8") as fh:
+#     long_description = fh.read()
 
 setuptools.setup(
     name="parm",
     version="0.1.0",
     python_requires=">=3.8",
-    extras_require=[
-        "pysb>=1.13.2",
-        "cython>=0.29.25",
-    ],
+    install_requires=["pysb>=1.13.2"],
+    extras_require={"cython": "cython>=0.29.25"},
     author="Blake A. Wilson",
     author_email="blake.wilson@utdallas.edu",
-    description="PAR2 Activation and calcium signaling Reaction Model .",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
+    description="PAR2 Activation and calcium signaling Reaction Model.",
+    # long_description=long_description,
+    # long_description_content_type="text/markdown",
     url="https://github.com/NTBEL/PARM",
     packages=setuptools.find_packages(),
     classifiers=[


### PR DESCRIPTION
### Changed
* Starting semantic versioning of the model code at v0.1.0.
* Made the `parm.util.pre_equilibration` function private by renaming to `parm.util._pre_equilibration`.
* The main PARM model `parm.parm` is now imported in the package `__init__.py` so that it can be imported like `from parm import model`.
* Moved the pysb dependency in setup.py to the `install_requires` list.

### Added
* Additional sections (Install, License, etc.) and information in the README, as well as shields/badges towards the top of the README.
* New wrapper function for pre-equilibration in the `util` module, `parm.util.pre_equilibrate` that calls the `_pre_equilibration` function but also does addtional steps to automate the process of setting 2AT to zero concentration and adjusting the baseline cytosolic calcium concentration used for the FRET ratio. This function also has a simpler output that contains an updated parameter vector and the initial concentrations that can be directly passed to the `run_model` function.
* New utility function `parm.util.calcium_homeostasis_reverse_rate_coupling` that adjusts a parameter vector to account for coupling of the reverse rates of the calcium homeostasis reactions to the forward rates. This function can be used adjust the parameters when sampling values of the reverse rate parameters for those reactions: for example, during model training.
* New default parameter vector, `default_param_values` created in the package `__init__.py` for the main `parm.parm` model which can be imported like `from parm import default_param_values`.
* New dictionary of parameter vector masks for fancy indexing, `parameter_masks`, created for the main `parm.parm` model which can imported like `from parm import parameter_masks`.
* Utility function `parm.util.get_parameter_vector` that takes a PySB model and returns a vector of the parameter values.
* Utiltiy function `parm.util.get_parameter_mask` that takes a PySB model and parameter name and returns a boolean mask to fancy index the corresponding paramter value vector for that particular parameter.
* Utility function `parm.util.set_tat_initial_nM` that takes a parameter value vector and an initial concentration of 2AT in nM and updates the parameter vector with the desired 2AT concentration.

### Fixed
* Converted the `extras_require` argument in the setup.py to be dictionary instead of a list, now with just the optional Cython dependency. Note that the pysb dependency was moved into the `install_requires` list.
* Commented out the `long_description` in setup.py because it was causing error when trying to read the README file.